### PR TITLE
嵌套滑动：优化嵌套滑动逻辑

### DIFF
--- a/calendar/src/main/java/com/ldf/calendar/Utils.java
+++ b/calendar/src/main/java/com/ldf/calendar/Utils.java
@@ -261,7 +261,7 @@ public final class Utils {
     /**
      * 判断上一次滑动改变周月日历是向下滑还是向上滑 向下滑表示切换为月日历模式 向上滑表示切换为周日历模式
      *
-     * @return boolean 是否是在向下滑动
+     * @return boolean 是否是在向下滑动。(true: 已经收缩; false: 已经打开）
      */
     public static boolean isScrollToBottom() {
         return customScrollToBottom;

--- a/calendar/src/main/java/com/ldf/calendar/behavior/RecyclerViewBehavior.java
+++ b/calendar/src/main/java/com/ldf/calendar/behavior/RecyclerViewBehavior.java
@@ -4,12 +4,11 @@ import android.content.Context;
 import android.support.design.widget.CoordinatorLayout;
 import android.support.v4.view.ViewCompat;
 import android.support.v4.view.ViewPager;
-import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.util.AttributeSet;
 import android.util.Log;
 import android.view.View;
-import android.widget.Scroller;
+import android.widget.Toast;
 
 import com.ldf.calendar.Utils;
 import com.ldf.calendar.view.MonthPager;
@@ -19,6 +18,8 @@ public class RecyclerViewBehavior extends CoordinatorLayout.Behavior<RecyclerVie
     private int minOffset = -1;
     private Context context;
     private boolean initiated = false;
+    boolean hidingTop = false;
+    boolean showingTop = false;
 
     public RecyclerViewBehavior(Context context, AttributeSet attrs) {
         super(context, attrs);
@@ -40,7 +41,7 @@ public class RecyclerViewBehavior extends CoordinatorLayout.Behavior<RecyclerVie
             initOffset = monthPager.getViewHeight();
             saveTop(initOffset);
         }
-        if(!initiated) {
+        if (!initiated) {
             initOffset = monthPager.getViewHeight();
             saveTop(initOffset);
             initiated = true;
@@ -52,32 +53,37 @@ public class RecyclerViewBehavior extends CoordinatorLayout.Behavior<RecyclerVie
     @Override
     public boolean onStartNestedScroll(CoordinatorLayout coordinatorLayout, RecyclerView child,
                                        View directTargetChild, View target, int nestedScrollAxes) {
-        Log.e("ldf","onStartNestedScroll");
-        LinearLayoutManager linearLayoutManager = (LinearLayoutManager) child.getLayoutManager();
-        if (linearLayoutManager.findFirstCompletelyVisibleItemPosition() > 0) {
-            return false;
-        }
+        Log.e("ldf", "onStartNestedScroll");
+
         MonthPager monthPager = (MonthPager) coordinatorLayout.getChildAt(0);
-        if (monthPager.getPageScrollState() != ViewPager.SCROLL_STATE_IDLE) {
-            return false;
-        }
         monthPager.setScrollable(false);
         boolean isVertical = (nestedScrollAxes & ViewCompat.SCROLL_AXIS_VERTICAL) != 0;
-        int firstRowVerticalPosition =
-                (child == null || child.getChildCount() == 0) ? 0 : child.getChildAt(0).getTop();
-        boolean recyclerViewTopStatus = firstRowVerticalPosition >= 0;
-        return isVertical
-                && (recyclerViewTopStatus || !Utils.isScrollToBottom())
-                && child == directTargetChild;
+
+        return isVertical;
     }
 
     @Override
     public void onNestedPreScroll(CoordinatorLayout coordinatorLayout, RecyclerView child,
                                   View target, int dx, int dy, int[] consumed) {
-        Log.e("ldf","onNestedPreScroll");
+        Log.e("ldf", "onNestedPreScroll");
         super.onNestedPreScroll(coordinatorLayout, child, target, dx, dy, consumed);
-        if (child.getTop() <= initOffset
-                && child.getTop() >= getMonthPager(coordinatorLayout).getCellHeight()) {
+        child.setVerticalScrollBarEnabled(true);
+
+        MonthPager monthPager = (MonthPager) coordinatorLayout.getChildAt(0);
+        if (monthPager.getPageScrollState() != ViewPager.SCROLL_STATE_IDLE) {
+            consumed[1] = dy;
+            Log.w("ldf", "onNestedPreScroll: MonthPager dragging");
+            Toast.makeText(context, "loading month data", Toast.LENGTH_SHORT).show();
+            return;
+        }
+
+        // 上滑，正在隐藏顶部的日历
+        hidingTop = dy > 0 && child.getTop() <= initOffset
+                && child.getTop() > getMonthPager(coordinatorLayout).getCellHeight();
+        // 下滑，正在展示顶部的日历
+        showingTop = dy < 0 && !ViewCompat.canScrollVertically(target, -1);
+
+        if (hidingTop || showingTop) {
             consumed[1] = Utils.scroll(child, dy,
                     getMonthPager(coordinatorLayout).getCellHeight(),
                     getMonthPager(coordinatorLayout).getViewHeight());
@@ -87,22 +93,38 @@ public class RecyclerViewBehavior extends CoordinatorLayout.Behavior<RecyclerVie
 
     @Override
     public void onStopNestedScroll(final CoordinatorLayout parent, final RecyclerView child, View target) {
-        Log.e("ldf","onStopNestedScroll");
+        Log.e("ldf", "onStopNestedScroll");
         super.onStopNestedScroll(parent, child, target);
         MonthPager monthPager = (MonthPager) parent.getChildAt(0);
         monthPager.setScrollable(true);
         if (!Utils.isScrollToBottom()) {
-            if (initOffset - Utils.loadTop() > Utils.getTouchSlop(context)) {
-                Utils.scrollTo(parent, child, getMonthPager(parent).getCellHeight(), 200);
+            if (initOffset - Utils.loadTop() > Utils.getTouchSlop(context) && hidingTop) {
+                Utils.scrollTo(parent, child, getMonthPager(parent).getCellHeight(), 500);
             } else {
-                Utils.scrollTo(parent, child, getMonthPager(parent).getViewHeight(), 80);
+                Utils.scrollTo(parent, child, getMonthPager(parent).getViewHeight(), 150);
             }
         } else {
-            if (Utils.loadTop() - minOffset > Utils.getTouchSlop(context)) {
-                Utils.scrollTo(parent, child, getMonthPager(parent).getViewHeight(), 200);
+            if (Utils.loadTop() - minOffset > Utils.getTouchSlop(context) && showingTop) {
+                Utils.scrollTo(parent, child, getMonthPager(parent).getViewHeight(), 500);
             } else {
-                Utils.scrollTo(parent, child, getMonthPager(parent).getCellHeight(), 80);
+                Utils.scrollTo(parent, child, getMonthPager(parent).getCellHeight(), 150);
             }
+        }
+    }
+
+    @Override
+    public boolean onNestedFling(CoordinatorLayout coordinatorLayout, RecyclerView child, View target, float velocityX, float velocityY, boolean consumed) {
+        Log.d("ldf", "onNestedFling: velocityY: " + velocityY);
+        return super.onNestedFling(coordinatorLayout, child, target, velocityX, velocityY, consumed);
+    }
+
+    @Override
+    public boolean onNestedPreFling(CoordinatorLayout coordinatorLayout, RecyclerView child, View target, float velocityX, float velocityY) {
+        // 日历隐藏和展示过程，不允许RecyclerView进行fling
+        if (hidingTop || showingTop) {
+            return true;
+        } else {
+            return false;
         }
     }
 


### PR DESCRIPTION
1. 修复：当显示月时，RecyclerView概率性上滑问题；
2. 优化：根据滑动方向，展开或者收缩日历；
3. 优化：在一次滑动中，向下滚动RecyclerView, 连贯地展开日历；
4. MonthPager左右滑动未完成时，禁止滑动recycleView。

Signed-off-by: Jack Kwan <jianzhe.guan@gmail.com>